### PR TITLE
Profiles are now, actually loaded from YAML/hash... They weren't before.

### DIFF
--- a/lib/r509/Config.rb
+++ b/lib/r509/Config.rb
@@ -135,6 +135,11 @@ module R509
             @profiles[prof]
         end
 
+        # @return [Integer] The number of profiles
+        def num_profiles
+          @profiles.count
+        end
+
         # @return [Integer] the last CRL number
         def crl_number
             @crl_number
@@ -310,8 +315,6 @@ module R509
                 opts[:crl_number_file] = (ca_root_path + conf.delete('crl_number')).to_s
             end
 
-            # Create the instance.
-            ret = self.new(opts)
 
             # The remaining keys should all be profiles :)
             profs = {}
@@ -324,10 +327,8 @@ module R509
             end
             opts[:profiles] = profs
 
-            # Read in revoked certificates.
-            ret.load_revoke_crl_list()
-
-            ret
+            # Create the instance.
+            self.new(opts)
         end
 
         # Loads the named configuration config from a yaml file.

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -18,6 +18,7 @@ describe R509::Config do
         its(:ocsp_location) {should be_nil}
         its(:crl_number) {should == 0}
         its(:revoked_certs) {should == []}
+        its(:num_profiles) {should == 0}
 
         it "should have the proper CA cert" do
             @config.ca_cert.to_pem.should == TestFixtures.test_ca_cert.to_pem
@@ -172,6 +173,12 @@ describe R509::Config do
             config.crl_validity_hours.should == 168
             config.message_digest.should == "SHA1"
             config.crl_number.should == 10
+            config.num_profiles.should == 2
+        end
+
+        it "should load YAML which only has a CA Cert and Key defined" do
+            config = R509::Config.from_yaml("test_ca", File.read("#{File.dirname(__FILE__)}/fixtures/config_test_minimal.yaml"), {:ca_root_path => "#{File.dirname(__FILE__)}/fixtures"})
+            config.num_profiles.should == 0
         end
 
         it "should fail if YAML config is null" do

--- a/spec/fixtures/config_test_minimal.yaml
+++ b/spec/fixtures/config_test_minimal.yaml
@@ -1,0 +1,7 @@
+test_ca: {
+    ca_cert: {
+        cert: 'test_ca.cer',
+        key: 'test_ca.key'
+    }
+}
+config_is_string: "this is bogus"


### PR DESCRIPTION
Also got rid of redundant, call to load_revoke_crl_list().
