### PR TITLE
Some quick fixes to CRL.

### DIFF
--- a/lib/r509/Crl.rb
+++ b/lib/r509/Crl.rb
@@ -97,6 +97,7 @@ module R509
         # @param serial [Integer] serial number of the certificate to revoke
         # @param reason [Integer] reason for revocation
         # @param revoke_time [Integer]
+        # @param generate_and_save [Boolean] whether we want to generate the CRL and save its file (default=true)
         #
         #   reason codes defined by rfc 5280
         #   CRLReason ::= ENUMERATED {
@@ -110,7 +111,7 @@ module R509
         #         removeFromCRL           (8),
         #         privilegeWithdrawn      (9),
         #         aACompromise           (10) }
-        def revoke_cert(serial,reason=nil, revoke_time=Time.now.to_i)
+        def revoke_cert(serial,reason=nil, revoke_time=Time.now.to_i, generate_and_save=true)
             if not reason.to_i.between?(0,10)
                 reason = 0
             end
@@ -118,8 +119,10 @@ module R509
             reason = reason.to_i
             revoke_time = revoke_time.to_i
             @revoked_certs[serial] = {:reason => reason, :revoke_time => revoke_time}
-            generate_crl()
-            save_crl_list()
+            if generate_and_save
+                generate_crl()
+                save_crl_list()
+            end
             nil
         end
 
@@ -209,8 +212,10 @@ module R509
                 serial = serial.to_i
                 reason = (reason == '') ? nil : reason.to_i
                 revoke_time = (revoke_time == '') ? nil : revoke_time.to_i
-                self.revoke_cert(serial, reason, revoke_time)
+                self.revoke_cert(serial, reason, revoke_time, false)
             end
+            generate_crl
+            save_crl_list
             nil
         end
 

--- a/spec/crl_spec.rb
+++ b/spec/crl_spec.rb
@@ -18,9 +18,10 @@ describe R509::Crl do
     end
     it "can write the crl_number_file" do
         crl = R509::Crl.new(@test_ca_config)
-        crl.crl_number_file.string.should == ""
+        crl.crl_number_file.string.should == "1"
+        crl.crl_number_file.reopen("")
         crl.save_crl_number
-        crl.crl_number_file.string.should == "0"
+        crl.crl_number_file.string.should == "1"
     end
     it "adds a cert to the revocation list" do
         crl = R509::Crl.new(@test_ca_config)
@@ -118,11 +119,6 @@ describe R509::Crl do
         crl.revoke_cert(12345)
         crl.save_crl_list
         crl.crl_list_file.string.should match(/[0-9]+,[0-9]+,[0-9]+,[0-9]+,[0-9]+/)
-    end
-    it "writes crl number" do
-        crl = R509::Crl.new(@test_ca_config)
-        crl.save_crl_number
-        crl.crl_number_file.string.should == "0"
     end
     it "doesn't write the crl_number_file when it is nil" do
         config = R509::Config.new(


### PR DESCRIPTION
Loading empty CRL generates/signs a CRL even though nothing is in it. Loading a CRL with N revoked certs now only generates/saves 1 time, rather than N times. No longer writing the CRL file for each line while reading it.
