### PR TITLE
CaConfigPool

### DIFF
--- a/lib/r509/Config.rb
+++ b/lib/r509/Config.rb
@@ -85,6 +85,37 @@ module R509
             end
         end
 
+        # pool of configs, so we can support multiple CAs from a single config file
+        class CaConfigPool
+            # @option configs [Hash<String, R509::Config::CaConfig>] the configs to add to the pool
+            def initialize(configs)
+                @configs = configs
+            end
+
+            # get all the config names
+            def names
+                @configs.keys
+            end
+
+            # retrieve a particular config by its name
+            def [](name)
+                @configs[name]
+            end
+
+            # Loads the named configuration config from a yaml string.
+            # @param [String] conf_name The name of the config within the file. Note
+            #  that a single yaml file can contain more than one configuration.
+            # @param [String] yaml_file The filename to load yaml config data from.
+            def self.from_yaml(name, yaml_data, opts = {})
+                conf = YAML.load(yaml_data)
+                configs = {}
+                conf[name].each_pair do |ca_name, data|
+                    configs[ca_name] = R509::Config::CaConfig.load_from_hash(data, opts)
+                end
+                R509::Config::CaConfigPool.new(configs)
+            end
+        end
+
         # Stores a configuration for our CA.
         class CaConfig
             include R509::IOHelpers

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,6 +2,42 @@ require 'spec_helper'
 require 'r509/Config'
 require 'r509/Exceptions'
 
+describe R509::Config::CaConfigPool do
+    context "defined manually" do
+        it "has no configs" do
+            pool = R509::Config::CaConfigPool.new({})
+
+            pool["first"].should == nil
+        end
+
+        it "has one config" do
+            config = R509::Config::CaConfig.new(
+                :ca_cert => TestFixtures.test_ca_cert,
+                :profiles => { "first_profile" => R509::Config::CaProfile.new }
+            )
+
+            pool = R509::Config::CaConfigPool.new({
+                "first" => config
+            })
+
+            pool["first"].should == config
+        end
+    end
+
+    context "loaded from YAML" do
+        it "should load two configs" do
+            pool = R509::Config::CaConfigPool.from_yaml("certificate_authorities", File.read("#{File.dirname(__FILE__)}/fixtures/config_pool_test_minimal.yaml"), {:ca_root_path => "#{File.dirname(__FILE__)}/fixtures"})
+
+            pool.names.should == ["test_ca", "second_ca"]
+
+            pool["test_ca"].should_not == nil
+            pool["test_ca"].num_profiles.should == 0
+            pool["second_ca"].should_not == nil
+            pool["second_ca"].num_profiles.should == 0
+        end
+    end
+end
+
 describe R509::Config::CaConfig do
     context "when initialized with a cert and key" do
         before :each do

--- a/spec/fixtures/config_pool_test_minimal.yaml
+++ b/spec/fixtures/config_pool_test_minimal.yaml
@@ -1,0 +1,15 @@
+certificate_authorities: {
+    test_ca: {
+        ca_cert: {
+            cert: 'test_ca.cer',
+            key: 'test_ca.key'
+        }
+    },
+    second_ca: {
+        ca_cert: {
+            cert: 'test_ca.cer',
+            key: 'test_ca.key'
+        }
+    }
+}
+config_is_string: "this is bogus"


### PR DESCRIPTION
Lets you load multiple CaConfig objects from YAML, such that we can support multiple CAs. We're doing just that now, to a certain extent, in r509-ca-http.
