### PR TITLE
Add #remove_list_entry to ReaderWriter. Fixes #68

### DIFF
--- a/lib/r509/crl/administrator.rb
+++ b/lib/r509/crl/administrator.rb
@@ -91,6 +91,7 @@ module R509
       # @param serial [Integer] serial number of the certificate to remove from revocation
       def unrevoke_cert(serial)
         @revoked_certs.delete(serial)
+        @rw.remove_list_entry(serial)
         nil
       end
 

--- a/lib/r509/crl/reader_writer.rb
+++ b/lib/r509/crl/reader_writer.rb
@@ -13,6 +13,10 @@ module R509
         raise NotImplementedError, "You must call #write_list_entry on a subclass of ReaderWriter"
       end
 
+      def remove_list_entry
+        raise NotImplementedError, "You must call #remove_list_entry on a subclass of ReaderWriter"
+      end
+
       def write_number
         raise NotImplementedError, "You must call #write_number on a subclass of ReaderWriter"
       end
@@ -59,11 +63,31 @@ module R509
       # @param serial [Integer] serial number of the certificate to revoke
       # @param reason [Integer,nil] reason for revocation
       # @param revoke_time [Integer]
-      def write_list_entry(serial,revoke_time,reason)
+      def write_list_entry(serial, revoke_time, reason)
         return nil if @crl_list_file.nil?
 
         entry = [serial,revoke_time,reason].join(",")
         write_data(@crl_list_file, entry+"\n" ,'a:ascii-8bit')
+      end
+
+      # Remove a CRL list entry
+      # @param serial [Integer] serial number of the certificate to remove from the list
+      def remove_list_entry(serial)
+        return nil if @crl_list_file.nil?
+
+        data = read_data(@crl_list_file)
+
+        updated_list = []
+
+        data.each_line do |line|
+          line.chomp!
+          revoke_info = line.split(',', 3)
+          if revoke_info[0].to_i != serial
+            updated_list.push(line)
+          end
+        end
+        write_data(@crl_list_file, updated_list.join("\n")+"\n")
+        nil
       end
 
       # read the CRL number from a file or StringIO

--- a/lib/r509/io_helpers.rb
+++ b/lib/r509/io_helpers.rb
@@ -9,6 +9,12 @@ module R509
     # @param [String] mode The write mode
     def self.write_data(filename_or_io, data, mode='wb:ascii-8bit')
       if filename_or_io.respond_to?(:write)
+        if filename_or_io.kind_of?(StringIO) and mode != "a:ascii-8bit"
+          # Writing to a StringIO in a non-append mode. This requires
+          # us to rewind and truncate it first.
+          filename_or_io.rewind()
+          filename_or_io.truncate(0)
+        end
         filename_or_io.write(data)
       else
         return File.open(filename_or_io, mode) do |f|
@@ -22,6 +28,9 @@ module R509
     #  the file that you'd like to read, or an IO-like object.
     def self.read_data(filename_or_io)
       if filename_or_io.respond_to?(:read)
+        if filename_or_io.kind_of?(StringIO)
+          filename_or_io.rewind()
+        end
         filename_or_io.read()
       else
         return File.open(filename_or_io, 'rb:ascii-8bit') do |f|

--- a/spec/crl/reader_writer_spec.rb
+++ b/spec/crl/reader_writer_spec.rb
@@ -10,6 +10,10 @@ describe R509::CRL::ReaderWriter do
     expect { @rw.write_list_entry }.to raise_error(NotImplementedError)
   end
 
+  it "abstract base class raises error for remove_list_entry" do
+    expect { @rw.remove_list_entry }.to raise_error(NotImplementedError)
+  end
+
   it "abstract base class raises error for write_number" do
     expect { @rw.write_number }.to raise_error(NotImplementedError)
   end
@@ -63,6 +67,17 @@ describe R509::CRL::FileReaderWriter do
     sio.string.should == "1,1,\n"
     @rw.write_list_entry(2,2,1)
     sio.string.should == "1,1,\n2,2,1\n"
+  end
+
+  it "removes a crl list entry" do
+    sio = StringIO.new
+    @rw.crl_list_file = sio
+    @rw.write_list_entry(1,1,nil)
+    sio.string.should == "1,1,\n"
+    @rw.write_list_entry(2,2,1)
+    sio.string.should == "1,1,\n2,2,1\n"
+    @rw.remove_list_entry(2)
+    sio.string.should == "1,1,\n"
   end
 
   it "reads a number" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
+require 'simplecov'
+SimpleCov.start
 begin
-  require 'simplecov'
-  SimpleCov.start
   require 'coveralls'
   Coveralls.wear!
 rescue LoadError


### PR DESCRIPTION
Reminder: the FileReaderWriter class is subject to inherent race
conditions if you run more than one process that touches it. It is
recommended that you replace it with a subclass using a database.
