### PR TITLE
Add support for alternative digests in OCSP response signatures

### DIFF
--- a/lib/r509.rb
+++ b/lib/r509.rb
@@ -1,6 +1,8 @@
 # A module for building an easy to use CA. Includes CSR, Certificate, and CRL
 # support.
 module R509
+  require('r509/openssl/pkey_ex.rb')
+  require('r509/openssl/ocsp_ex.rb')
   require('r509/certificate_authority/signer.rb')
   require('r509/certificate_authority/options_builder.rb')
   require('r509/csr.rb')

--- a/lib/r509/openssl/ocsp_ex.rb
+++ b/lib/r509/openssl/ocsp_ex.rb
@@ -1,0 +1,49 @@
+# vim: set sts=2 ts=2 sw=2 et:
+require 'r509/openssl/pkey_ex'
+
+module OpenSSL::OCSP
+  module BasicResponseSigningExtension
+    # Use the internal signer to get everything set up, then resign with our digest
+    def sign(signer_cert, signer_key, certificates=nil, flags=nil, digest=OpenSSL::Digest::SHA1.new)
+      super(signer_cert, signer_key, certificates, flags)
+      signed_der = signer_key.sign_x509_der!(digest, self.to_der)
+      self.class.from_der(signed_der)
+    end
+
+    # Create an alias to make reponds_to? a viable test for this enhancement
+    alias_method :sign_with_digest, :sign
+
+    def to_der
+      # To get the DER, we create a response, get the DER,
+      # decode the DER to ASN.1, grab the basic member, and get the DER of that
+      
+      temp_status = OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL
+      res = OpenSSL::OCSP::Response.create(temp_status, self)
+      asn = OpenSSL::ASN1.decode(res.to_der)
+      
+      # OCSPResponse.(explicit).responseBytes.response is an octet string of DER
+      asn.value[1].value[0].value[1].value
+    end
+  end 
+  class BasicResponse
+    prepend OpenSSL::OCSP::BasicResponseSigningExtension
+
+    def self.from_der(bder)
+      # Given DER, manually build a OCSPResponse, parse it, and get the basicResponse
+      response_bytes = OpenSSL::ASN1::Sequence.new([
+        OpenSSL::ASN1::ObjectId.new("1.3.6.1.5.5.7.48.1.1"),
+        OpenSSL::ASN1::OctetString.new(bder)
+      ])
+
+      # Note that Explicit tagging requires wrapping the data in an array
+      # This is not documented well, but will raise an error if you do not
+      ocsp_response = OpenSSL::ASN1::Sequence.new([
+        OpenSSL::ASN1::Enumerated.new(OpenSSL::OCSP::RESPONSE_STATUS_SUCCESSFUL),
+        OpenSSL::ASN1::ASN1Data.new([response_bytes], 0, :CONTEXT_SPECIFIC)
+      ])
+      res_der = ocsp_response.to_der
+      res = OpenSSL::OCSP::Response.new(res_der)
+      res.basic
+    end 
+  end
+end 

--- a/lib/r509/openssl/pkey_ex.rb
+++ b/lib/r509/openssl/pkey_ex.rb
@@ -1,0 +1,100 @@
+# vim: set sts=2 ts=2 sw=2 et:
+module OpenSSL::PKey
+  class PKey
+    def sign_x509_der!(digest, der)
+      if !digest.kind_of? OpenSSL::Digest
+        raise OpenSSL::PKey::PKeyError, "must provide a Digest"
+      end
+      if !self.private?
+        raise OpenSSL::PKey::PKeyError, "must be a private key"
+      end
+      if der.kind_of? OpenSSL::ASN1::ASN1Data
+        der_out = false
+        asn = der
+      elsif der.kind_of? String
+        der_out = true
+        begin
+          asn = OpenSSL::ASN1.decode(der)
+        rescue OpenSSL::ASN1::ASN1Error => e
+          raise OpenSSL::PKey::PKeyError, "invalid DER (#{e.message})"
+        end
+      else
+        raise OpenSSL::PKey::PKeyError, "must provide ASN1Data or DER string"
+      end
+
+      # Sanity check the structure; it needs be a SEQUENCE with something to sign
+      if !asn.kind_of? OpenSSL::ASN1::Sequence
+        raise OpenSSL::PKey::PKeyError, "DER must be a sequence"
+      end
+      if (!asn.value.kind_of? Array) || (asn.value.length == 0) || (!asn.value[0].kind_of? OpenSSL::ASN1::ASN1Data)
+        raise OpenSSL::PKey::PKeyError, "DER must have data to be signed"
+      end
+
+      # Sign it
+      data = asn.value[0].to_der
+      asn.value[1] = OpenSSL::ASN1::Sequence.new(self.class.algorithm_identifier(digest))
+      asn.value[2] = OpenSSL::ASN1::BitString.new(self.sign(digest, data))
+      if der_out
+        return asn.to_der
+      else
+        return asn
+      end 
+    end
+  end
+
+  class RSA
+    def self.algorithm_identifier(hash)
+      if !((hash.kind_of? Class) || (hash.kind_of? OpenSSL::Digest))
+        raise OpenSSL::PKey::PKeyError, "Unknown digest type"
+      end
+      if hash == OpenSSL::Digest::SHA512 || (hash.kind_of? OpenSSL::Digest::SHA512)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.13"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::SHA384 || (hash.kind_of? OpenSSL::Digest::SHA384)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.12"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::SHA256 || (hash.kind_of? OpenSSL::Digest::SHA256)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.11"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::SHA1 || (hash.kind_of? OpenSSL::Digest::SHA1)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.5"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::MD5 || (hash.kind_of? OpenSSL::Digest::MD5)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.4"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::MD4 || (hash.kind_of? OpenSSL::Digest::MD4)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.3"), OpenSSL::ASN1::Null.new(nil)]
+      elsif hash == OpenSSL::Digest::MD2 || (hash.kind_of? OpenSSL::Digest::MD2)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.113549.1.1.2"), OpenSSL::ASN1::Null.new(nil)]
+      end
+      raise OpenSSL::PKey::PKeyError, "Unsupported digest algorithm"
+    end
+  end
+
+  class DSA
+    def self.algorithm_identifier(hash)
+      if !((hash.kind_of? Class) || (hash.kind_of? OpenSSL::Digest))
+        raise OpenSSL::PKey::PKeyError, "Unknown digest type"
+      end
+      if hash == OpenSSL::Digest::SHA256 || (hash.kind_of? OpenSSL::Digest::SHA256)
+        return [OpenSSL::ASN1::ObjectId.new("2.16.840.1.101.3.4.3.2")]
+      elsif hash == OpenSSL::Digest::SHA1 || (hash.kind_of? OpenSSL::Digest::SHA1)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.10040.4.3")]
+      end
+      raise OpenSSL::PKey::PKeyError, "Unsupported digest algorithm"
+    end
+  end
+
+  class EC
+    def self.algorithm_identifier(hash)
+      if !((hash.kind_of? Class) || (hash.kind_of? OpenSSL::Digest))
+        raise OpenSSL::PKey::PKeyError, "Unknown digest type"
+      end
+      if hash == OpenSSL::Digest::SHA512 || (hash.kind_of? OpenSSL::Digest::SHA512)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.10040.4.3.4")]
+      elsif hash == OpenSSL::Digest::SHA384 || (hash.kind_of? OpenSSL::Digest::SHA384)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.10045.4.3.3")]
+      elsif hash == OpenSSL::Digest::SHA256 || (hash.kind_of? OpenSSL::Digest::SHA256)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.10045.4.3.2")]
+      elsif hash == OpenSSL::Digest::SHA1 || (hash.kind_of? OpenSSL::Digest::SHA1)
+        return [OpenSSL::ASN1::ObjectId.new("1.2.840.10045.4.1")]
+      end
+      raise OpenSSL::PKey::PKeyError, "Unsupported digest algorithm"
+    end
+  end
+end 


### PR DESCRIPTION
Ruby's OpenSSL extension hard codes SHA-1 as the OCSP response signature digest algorithm.  This works around that limitation by replacing the signature before returning the signed response to the caller.